### PR TITLE
Updated User-Agent header to 2021 standards + Correcting old branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rprxy
 
-Because ROBLOX does not allow HttpService requests to roblox.com an external proxy is needed for access to site APIs.
-This will proxy all requests to ROBLOX via `server.js` except when the path is `/proxy` and a static file exists.
+Because Roblox does not allow HttpService requests to roblox.com an external proxy is needed for access to site APIs.
+This will proxy all requests to Roblox via `server.js` except when the path is `/proxy` and a static file exists.
 
 A limited number of APIs are available via the `/proxy/api` path via `api.js`.
 

--- a/server.js
+++ b/server.js
@@ -65,7 +65,7 @@ function onProxyError (err, req, res) {
 }
 
 function onProxyReq (proxyReq, req, res, options) {
-  proxyReq.setHeader('User-Agent', 'Mozilla');
+  proxyReq.setHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36');
   proxyReq.removeHeader('roblox-id');
 }
 

--- a/static/about.html
+++ b/static/about.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-			<title>ROBLOX Proxy and APIs</title>
+			<title>Roblox Proxy and APIs</title>
 
 		<link rel="stylesheet" href="/proxy/css/pure-min.css">
 		<link rel="stylesheet" href="/proxy/css/side-menu.css">

--- a/static/api.html
+++ b/static/api.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-			<title>ROBLOX Proxy and APIs</title>
+			<title>Roblox Proxy and APIs</title>
 
 		<link rel="stylesheet" href="/proxy/css/pure-min.css">
 		<link rel="stylesheet" href="/proxy/css/side-menu.css">

--- a/static/home.html
+++ b/static/home.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-			<title>ROBLOX Proxy and APIs</title>
+			<title>Roblox Proxy and APIs</title>
 
 		<link rel="stylesheet" href="/proxy/css/pure-min.css">
 		<link rel="stylesheet" href="/proxy/css/side-menu.css">
@@ -32,7 +32,7 @@
 
 			<div id="main">
 				<div class="header">
-					<h1>ROBLOX Proxy and APIs</h1>
+					<h1>Roblox Proxy and APIs</h1>
 				</div>
 
 				<div class="content">


### PR DESCRIPTION
Hey!

I've updated a couple files, the biggest change is changing the user-agent header to work with all Roblox domains, a decent amount of subdomains do not accept just "mozilla" as the user agent header; `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36` [is the new standard.](https://user-agents.net/string/mozilla-5-0-windows-nt-10-0-win64-x64-applewebkit-537-36-khtml-like-gecko-chrome-74-0-3729-169-safari-537-36)

I've also gone ahead and updated the terminology "ROBLOX" to the new branding, "Roblox". 

Thanks for the awesome resource!

